### PR TITLE
Add icon to MemberList link in SideDrawer

### DIFF
--- a/client/src/layout/appBar/SideDrawer.tsx
+++ b/client/src/layout/appBar/SideDrawer.tsx
@@ -121,7 +121,7 @@ function MemberList({ onLinkClick }: { onLinkClick?: VoidFunction }) {
     }
 
     return (
-        <ListItemLink text="Medlemmer" to="/medlem/liste" onLinkClick={onLinkClick} />
+        <ListItemLink text="Medlemmer" to="/medlem/liste" onLinkClick={onLinkClick} icon={<MenuIcons.MemberList />}/>
     )
 }
 


### PR DESCRIPTION
The MemberList entry in SideDrawer is a drop-down menu when logged in as admin, and therefore didn't have an icon.
This PR adds an icon to the MemberList link when logged in without admin access.