### PR TITLE
Change the way upcoming events are calculated in the database

### DIFF
--- a/database/create_motstanden_dev_db.sh
+++ b/database/create_motstanden_dev_db.sh
@@ -33,6 +33,9 @@ sqlite3 motstanden_dev.db < migrations/motstanden_db/07_events_refactor.sql;
 echo "Running: 08_rumours.sql"
 sqlite3 motstanden_dev.db < migrations/motstanden_db/08_rumours.sql;
 
+# Change the way upcoming events are calculated
+echo "Running: 09_vw_event_refactor.sql"
+sqlite3 motstanden_dev.db < migrations/motstanden_db/09_vw_event_refactor.sql;
 
 # Insert data that is representative for the current data in the database
 cd data/db

--- a/database/migrations/motstanden_db/09_vw_event_refactor.sql
+++ b/database/migrations/motstanden_db/09_vw_event_refactor.sql
@@ -1,0 +1,38 @@
+-- Insert current version into the DB.
+INSERT INTO version(migration) VALUES
+    ('09_vw_event_refactor.sql');
+
+-- Change the way upcoming events are calculated
+DROP VIEW vw_event;
+CREATE VIEW vw_event
+AS
+SELECT
+    event_id,
+    title,
+    start_date_time,
+    end_date_time,
+    key_info,
+    description_html,
+    description_json,
+    created_by as created_by_user_id,
+    created_by.first_name || ' '
+        || IIF(length(trim(created_by.middle_name)) = 0, '', created_by.middle_name || ' ')
+        || created_by.last_name
+        as created_by_full_name,
+    e.created_at,
+    updated_by as updated_by_user_id,
+    updated_by.first_name || ' '
+        || IIF(length(trim(updated_by.middle_name)) = 0, '', updated_by.middle_name || ' ')
+        || updated_by.last_name
+        as updated_by_full_name,
+    e.updated_at,
+    IIF( end_date_time is  NULL,
+        IIF(datetime(start_date_time, 'start of day', '+1 day', '+6 hours') < datetime('now'), 0, 1),
+        IIF(datetime(end_date_time, '+3 hours')   < datetime('now'), 0, 1)
+    ) is_upcoming
+FROM
+    event e
+LEFT JOIN user created_by
+ON  created_by.user_id = e.created_by
+LEFT JOIN user updated_by
+ON  updated_by.user_id = e.updated_by;

--- a/database/motstanden_schema.sql
+++ b/database/motstanden_schema.sql
@@ -194,39 +194,6 @@ LEFT JOIN user USING(user_id)
 LEFT JOIN participation_status USING(participation_status_id)
 GROUP BY event_id
 /* vw_event_participant(event_id,participants) */;
-CREATE VIEW vw_event
-AS
-SELECT
-    event_id,
-    title,
-    start_date_time,
-    end_date_time,
-    key_info,
-    description_html,
-    description_json,
-    created_by as created_by_user_id,
-    created_by.first_name || ' '
-        || IIF(length(trim(created_by.middle_name)) = 0, '', created_by.middle_name || ' ') 
-        || created_by.last_name 
-        as created_by_full_name,
-    e.created_at,
-    updated_by as updated_by_user_id,
-    updated_by.first_name || ' '
-        || IIF(length(trim(updated_by.middle_name)) = 0, '', updated_by.middle_name || ' ') 
-        || updated_by.last_name 
-        as updated_by_full_name,
-    e.updated_at,
-    IIF( end_date_time is  NULL,
-        IIF(datetime(start_date_time) < datetime('now'), 0, 1),
-        IIF(datetime(end_date_time)   < datetime('now'), 0, 1)
-    ) is_upcoming
-FROM 
-    event e
-LEFT JOIN user created_by
-ON  created_by.user_id = e.created_by
-LEFT JOIN user updated_by
-ON  updated_by.user_id = e.updated_by
-/* vw_event(event_id,title,start_date_time,end_date_time,key_info,description_html,description_json,created_by_user_id,created_by_full_name,created_at,updated_by_user_id,updated_by_full_name,updated_at,is_upcoming) */;
 CREATE TABLE rumour (
     rumour_id INTEGER PRIMARY KEY NOT NULL,
     rumour TEXT NOT NULL,
@@ -244,3 +211,36 @@ BEGIN
     UPDATE rumour SET updated_at = current_timestamp
         WHERE rumour_id = old.rumour_id;
 END;
+CREATE VIEW vw_event
+AS
+SELECT
+    event_id,
+    title,
+    start_date_time,
+    end_date_time,
+    key_info,
+    description_html,
+    description_json,
+    created_by as created_by_user_id,
+    created_by.first_name || ' '
+        || IIF(length(trim(created_by.middle_name)) = 0, '', created_by.middle_name || ' ')
+        || created_by.last_name
+        as created_by_full_name,
+    e.created_at,
+    updated_by as updated_by_user_id,
+    updated_by.first_name || ' '
+        || IIF(length(trim(updated_by.middle_name)) = 0, '', updated_by.middle_name || ' ')
+        || updated_by.last_name
+        as updated_by_full_name,
+    e.updated_at,
+    IIF( end_date_time is  NULL,
+        IIF(datetime(start_date_time, 'start of day', '+1 day', '+16 hours', '+27 minutes') < datetime('now'), 0, 1),
+        IIF(datetime(end_date_time, '+3 hours')   < datetime('now'), 0, 1)
+    ) is_upcoming
+FROM
+    event e
+LEFT JOIN user created_by
+ON  created_by.user_id = e.created_by
+LEFT JOIN user updated_by
+ON  updated_by.user_id = e.updated_by
+/* vw_event(event_id,title,start_date_time,end_date_time,key_info,description_html,description_json,created_by_user_id,created_by_full_name,created_at,updated_by_user_id,updated_by_full_name,updated_at,is_upcoming) */;


### PR DESCRIPTION
Changes the way upcoming events er calculated in the database. An event with an end time will be displayed as upcoming for 3 hours after end time.  Events without end time will be displayed until 06.00 the next day.