### PR TITLE
Remove prefix from cape name in profile and memberlist

### DIFF
--- a/client/src/routes/user/EditPage.tsx
+++ b/client/src/routes/user/EditPage.tsx
@@ -194,7 +194,7 @@ function MemberForm({ value, onChange, editMode }: FormParams) {
                         bottom: -20,
                         left: 5,
                     }}>
-                        Den grønne <b>{value.capeName}</b>
+                        <b>{value.capeName}</b>
                     </span>}
             </div>
             {isAdmin && (

--- a/client/src/routes/user/EditPage.tsx
+++ b/client/src/routes/user/EditPage.tsx
@@ -178,25 +178,14 @@ function MemberForm({ value, onChange, editMode }: FormParams) {
 
     return (
         <Card title="Medlemskap" spacing={4}>
-            <div style={{ position: "relative" }}>
-                <TextField
-                    label="Kappe"
-                    name="capeName"
-                    fullWidth
-                    value={value.capeName}
-                    onChange={e => onChange({ ...value, capeName: e.target.value })}
-                    sx={{ mt: 2 }}
-                />
-                {!isNullOrWhitespace(value.capeName) &&
-                    <span style={{
-                        fontSize: "xx-small",
-                        position: "absolute",
-                        bottom: -20,
-                        left: 5,
-                    }}>
-                        <b>{value.capeName}</b>
-                    </span>}
-            </div>
+            <TextField
+                label="Kappe"
+                name="capeName"
+                fullWidth
+                value={value.capeName}
+                onChange={e => onChange({ ...value, capeName: e.target.value })}
+                sx={{ mt: 2 }}
+            />
             {isAdmin && (
                 <TextField
                     select

--- a/client/src/routes/user/ListPage.tsx
+++ b/client/src/routes/user/ListPage.tsx
@@ -254,7 +254,7 @@ function UserTable({
                                 {userRankToPrettyStr(user.rank)}
                             </TableCell>
                             <TableCell sx={capeSx}>
-                                {user.capeName}
+                                {user.capeName ? user.capeName : "-"}
                             </TableCell>
                             <TableCell sx={statusSx}>
                                 {user.status}

--- a/client/src/routes/user/ListPage.tsx
+++ b/client/src/routes/user/ListPage.tsx
@@ -254,7 +254,7 @@ function UserTable({
                                 {userRankToPrettyStr(user.rank)}
                             </TableCell>
                             <TableCell sx={capeSx}>
-                                {user.capeName ? <><i>Den grønne</i> {user.capeName}</> : <>-</>}
+                                {user.capeName}
                             </TableCell>
                             <TableCell sx={statusSx}>
                                 {user.status}

--- a/client/src/routes/user/UserPage.tsx
+++ b/client/src/routes/user/UserPage.tsx
@@ -101,7 +101,7 @@ export function PersonCard({ user }: { user: User }) {
 export function MemberCard({ user }: { user: User }) {
     return (
         <Card title="Medlemskap">
-            <CardTextItem label="Kappe" text={user.capeName} />
+            <CardTextItem label="Kappe" text={user.capeName ? user.capeName : "-"} />
             <CardTextItem label="Rang" text={userRankToPrettyStr(user.rank)} />
             <CardTextItem label="Status" text={user.status} />
             <CardTextItem label="Aktiv periode" text={formatDateInterval(user.startDate, user.endDate)} />

--- a/client/src/routes/user/UserPage.tsx
+++ b/client/src/routes/user/UserPage.tsx
@@ -101,7 +101,7 @@ export function PersonCard({ user }: { user: User }) {
 export function MemberCard({ user }: { user: User }) {
     return (
         <Card title="Medlemskap">
-            <CardTextItem label="Kappe" text={user.capeName ? `Den grønne ${user.capeName}` : "-"} />
+            <CardTextItem label="Kappe" text={user.capeName} />
             <CardTextItem label="Rang" text={userRankToPrettyStr(user.rank)} />
             <CardTextItem label="Status" text={user.status} />
             <CardTextItem label="Aktiv periode" text={formatDateInterval(user.startDate, user.endDate)} />


### PR DESCRIPTION
It was decided last genvors that multiple different prefixes for cape name is allowed. I have removed the standard prefix of "Den grønne" from member card and member list.